### PR TITLE
fix: link to docs.anyscale.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the Anyscale Examples Repo!
 
-This repo contains example workloads you can run on Anyscale. Please see the [Anyscale Docs](docs.anyscale.com) to see complete user guides using these examples.
+This repo contains example workloads you can run on Anyscale. Please see the [Anyscale Docs](https://docs.anyscale.com) to see complete user guides using these examples.
 
 * [hello_world.py](/hello_world.py): A basic Hello World example
 * [serve_hello.py](/serve_hello.py): A basic Serve example


### PR DESCRIPTION
Fixes a relative link which is currently 404'ing and should be absolute.