### PR TITLE
[fix] server_hello.py - broken example code

### DIFF
--- a/serve_hello.py
+++ b/serve_hello.py
@@ -5,8 +5,6 @@ import os
 # Use this var to test service inplace update. When the env var is updated, users see new return value.
 msg = os.getenv("SERVE_RESPONSE_MESSAGE", "Hello world!")
 
-serve.start(detached=True)
-
 app = FastAPI()
 
 @serve.deployment(route_prefix="/")


### PR DESCRIPTION
The example python for serve_hello.py has a deprecated call to `serve.start(detached=true)`
This was causing the Anyscale serve service to fail and getting caught in a service crash loop.

After troubleshooting by changing the service.yaml example, it was tracked to the `server.start` line of code in the python.

This will be followed up with an additional PR in the docs_examples repo. Issue logged here: anyscale/product#17563

On branch production-service-broken-example-fix
Changes to be committed:
	modified:   serve_hello.py