### PR TITLE
Kamen/update serve examples

### DIFF
--- a/sentiment_analysis/app.py
+++ b/sentiment_analysis/app.py
@@ -21,3 +21,4 @@ model = LanguageModel.bind()
 # The following block will be executed if the script is run by Python directly
 if __name__ == "__main__":
     serve.run(model)
+    

--- a/sentiment_analysis/app.py
+++ b/sentiment_analysis/app.py
@@ -18,3 +18,6 @@ class LanguageModel:
 
 model = LanguageModel.bind()
 
+# The following block will be executed if the script is run by Python directly
+if __name__ == "__main__":
+    serve.run(model)

--- a/stable-diffusion/app.py
+++ b/stable-diffusion/app.py
@@ -56,5 +56,6 @@ class StableDiffusionV2:
 
 entrypoint = APIIngress.bind(StableDiffusionV2.bind())
 
-# Run the script with `serve run app:entrypoint` to start the serve application
-
+# The following block will be executed if the script is run by Python directly
+if __name__ == "__main__":
+    serve.run(entrypoint)

--- a/stable-diffusion/cluster_env.yaml
+++ b/stable-diffusion/cluster_env.yaml
@@ -12,5 +12,6 @@ python:
   - torch==1.13.0
   - torchvision==0.14.0
   - transformers==4.24.0
+  - numpy==1.23.0
   conda_packages: []
 post_build_cmds: []


### PR DESCRIPTION
Update the serve examples to run directly with python call. Stable diffusion also needs numpy version < 1.24 to run properly. 

Tested locally